### PR TITLE
A95X F3 Air: Add configuration

### DIFF
--- a/a95x-f3-air-vfd.conf
+++ b/a95x-f3-air-vfd.conf
@@ -1,0 +1,36 @@
+# This file must be renamed to vfd.conf and placed in the /storage/.config/ folder.
+#
+# A95X F3 Air - S905X3 configuration
+#--------------------
+#gpio_xxx:
+# [0] 0 = &gpio, 1 = &gpio_ao.
+# [1] pin number - https://github.com/torvalds/linux/blob/master/include/dt-bindings/gpio/meson-g12a-gpio.h
+# [2] Reserved - must be 0.
+
+vfd_gpio_clk='1,7,0'
+vfd_gpio_dat='1,8,0'
+vfd_gpio_stb='1,6,0'
+
+#chars:
+# < DHHMM > Order of display chars (D=dots, represented by a single char)
+
+vfd_chars='4,0,1,2,3'
+
+#dot_bits:
+# Order of dot bits. Typical configurations:
+# Display Type 0, 1 usually has Alarm, USB, Play, Pause, Col, Ethernet, Wifi dots
+# Alarm = 0, USB = 1, Play = 2, Pause = 3, Col = 4, Eth = 5, Wifi = 6
+# Display Type 2 usually has APPS, USB, SETUP, CARD, Col, HDMI, CVBS dots
+# APPS = 0, USB = 1, SETUP = 2, CARD = 3, Col = 4, HDMI = 5, CVBS = 6
+# Display Type 3 Power, LAN, Col, Low Wifi, High Wifi
+# N/A = 0, N/A = 1, Power = 2, LAN = 3, Col = 4, High Wifi = 5, Low Wifi = 6
+
+vfd_dot_bits='0,1,2,3,4,5,6'
+
+#display_type:
+# [0] - Display type.
+# [1] - Reserved - must be 0.
+# [2] - Flags. (bit 0 = '1' - Common Anode display, bits [1-7] - Reserved.)
+# [3] - Controller.
+
+vfd_display_type='0x03,0x00,0x00,0x00'


### PR DESCRIPTION
This PR adds support for the `A95X F3 Air` (Amlogic S905X3) TV box